### PR TITLE
Fix deadline

### DIFF
--- a/functional_tests/test_enter_picks.py
+++ b/functional_tests/test_enter_picks.py
@@ -430,8 +430,9 @@ class EnterPicksTest(FunctionalTest):
         test_db = UnitTestDatabase()
         test_db.setup_week_not_started_no_picks(1978,1)
 
-        # verify week lock picks is None
+        # verify week pick deadline is None
         week = get_week(1978,1) 
+        self.assertIsNone(week.pick_deadline)
         self.assertFalse(week.lock_picks)
 
         # login a user and open the picks page
@@ -453,8 +454,9 @@ class EnterPicksTest(FunctionalTest):
         test_db = UnitTestDatabase()
         test_db.setup_week_in_progress(1978,1)
 
-        # verify week lock picks is None
+        # verify week pick deadline is None
         week = get_week(1978,1) 
+        self.assertIsNone(week.pick_deadline)
         self.assertFalse(week.lock_picks)
 
         # login a user and open the picks page
@@ -472,8 +474,9 @@ class EnterPicksTest(FunctionalTest):
         test_db = UnitTestDatabase()
         test_db.setup_week_final(1978,1)
 
-        # verify week lock picks is None
+        # verify week pick deadline is None
         week = get_week(1978,1) 
+        self.assertIsNone(week.pick_deadline)
         self.assertFalse(week.lock_picks)
 
         # login a user and open the picks page
@@ -643,8 +646,30 @@ class EnterPicksTest(FunctionalTest):
 
         test_db.delete_database()
 
+    def test_picks_locked(self):
+        test_db = UnitTestDatabase()
+        test_db.setup_week_not_started_no_picks(1978,1)
+
+        self.utils.lock_picks(1978,1)
+
+        # login a user and open the picks page
+        player = self.utils.get_player_from_public_name(1978,'Brent')
+        self.utils.login_assigned_user(name='Brent',player=player)
+        self.utils.enter_picks_page(year=1978,week=1,player_id=player.id)
+
+        body = self.browser.find_element_by_tag_name('body').text
+        expected = "Picks are currently locked and cannot be entered."
+        self.assertIn(expected,body)
+
+        test_db.delete_database()
+
+
     @unittest.skip('not implemented yet')
     def test_POST_invalid_year(self):
+        pass
+
+    @unittest.skip('not implemented yet')
+    def test_POST_picks_locked(self):
         pass
 
     @unittest.skip('not implemented yet')

--- a/functional_tests/utils.py
+++ b/functional_tests/utils.py
@@ -151,7 +151,18 @@ class Utils:
         naive_dt_now = dt.datetime.now()
         naive_dt_deadline = dt.datetime(naive_dt_now.year, naive_dt_now.month, naive_dt_now.day, 16, 0, 0) + timedelta(days=days_until_expired)
         deadline = pytz.timezone('US/Eastern').localize(naive_dt_deadline)
-        week.lock_picks = deadline
+        week.pick_deadline = deadline
+        week.lock_picks = False
+        week.save()
+
+    def lock_picks(self,year,week_number):
+        week = get_week(year,week_number)
+        week.lock_picks = True
+        week.save()
+
+    def unlock_picks(self,year,week_number):
+        week = get_week(year,week_number)
+        week.lock_picks = False
         week.save()
 
     def unlock_game_scores(self,year,week_number):

--- a/pick10/calculator.py
+++ b/pick10/calculator.py
@@ -436,7 +436,7 @@ class CalculateResults:
             return True
 
         picks_entered_after_pick_deadline = submit_time > week.pick_deadline
-        if picks_entered_after_pick_deadline or week.lock_picks:
+        if picks_entered_after_pick_deadline:
             return True
 
         return False

--- a/pick10/database.py
+++ b/pick10/database.py
@@ -161,18 +161,18 @@ class Database:
         return week_numbers_and_years
 
     def __before_pick_deadline(self,week):
-        if week.lock_picks == None or week.pick_deadline == None:
+        if week.pick_deadline == None:
             return False
         current_time = datetime.datetime.utcnow()
         current_time_tz = pytz.timezone('UTC').localize(current_time)
-        return not week.lock_picks and current_time_tz <= week.pick_deadline
+        return current_time_tz <= week.pick_deadline
 
     def __after_pick_deadline(self,week):
-        if week.lock_picks == None or week.pick_deadline == None:
+        if week.pick_deadline == None:
             return False
         current_time = datetime.datetime.utcnow()
         current_time_tz = pytz.timezone('UTC').localize(current_time)
-        return not week.lock_picks and current_time_tz > week.pick_deadline
+        return current_time_tz > week.pick_deadline
 
     def update_games_cache(self,year,week_number,data):
         raise AssertionError,"Not implemented"

--- a/pick10/database.py
+++ b/pick10/database.py
@@ -30,6 +30,10 @@ class Database:
         week = self.__get_week_in_database(year,week_number)
         return week.lock_scores
 
+    def are_picks_locked(self,year,week_number):
+        week = self.__get_week_in_database(year,week_number)
+        return week.lock_picks
+
     def before_pick_deadline(self,year,week_number):
         # TODO tests
         week = self.__get_week_in_database(year,week_number)

--- a/pick10/enter_picks_view.py
+++ b/pick10/enter_picks_view.py
@@ -41,7 +41,15 @@ class EnterPicksView:
             WeekNavbar(year,week_number,'enter_picks',request.user).add_parameters(data)
             return render(request,"pick10/enter_picks_error.html",data)
 
-        week_state = Database().get_week_state(year,week_number)
+        d = Database()
+
+        if d.are_picks_locked(year,week_number):
+            data = self.__setup_basic_params(year,week_number)
+            data['error'] = 'picks_locked'
+            WeekNavbar(year,week_number,'enter_picks',request.user).add_parameters(data)
+            return render(request,"pick10/enter_picks_error.html",data)
+
+        week_state = d.get_week_state(year,week_number)
 
         if week_state == IN_PROGRESS:
             data = self.__setup_basic_params(year,week_number)
@@ -95,7 +103,15 @@ class EnterPicksView:
             data['error'] = 'user_player_mismatch'
             return render(request,"pick10/enter_picks_error.html",data)
 
-        week_state = Database().get_week_state(year,week_number)
+        d = Database()
+
+        if d.are_picks_locked(year,week_number):
+            data = self.__setup_basic_params(year,week_number)
+            data['error'] = 'picks_locked'
+            WeekNavbar(year,week_number,'enter_picks',request.user).add_parameters(data)
+            return render(request,"pick10/enter_picks_error.html",data)
+
+        week_state = d.get_week_state(year,week_number)
 
         if week_state == IN_PROGRESS:
             data = self.__setup_basic_params(year,week_number)

--- a/pick10/tests/test_calculator.py
+++ b/pick10/tests/test_calculator.py
@@ -620,16 +620,16 @@ class CalculatorTests(TestCase):
         self.__t36_pick_updated_entry_time()
 
     def test_t36_3_get_player_submit_time(self):
-        self.__t36_week_lock_picks_not_specified()
+        self.__t36_week_pick_deadline_not_specified()
 
     def test_t36_4_get_player_submit_time(self):
-        self.__t36_submit_after_week_lock()
+        self.__t36_submit_after_week_deadline()
 
     def test_t36_5_get_player_submit_time(self):
-        self.__t36_submit_before_week_lock()
+        self.__t36_submit_before_week_deadline()
 
     def test_t36_6_get_player_submit_time(self):
-        self.__t36_submit_same_as_week_lock()
+        self.__t36_submit_same_as_week_deadline()
 
     def __t1_invalid_player(self):
         bad_player = Player()
@@ -2600,13 +2600,11 @@ class CalculatorTests(TestCase):
         self.__change_player_pick_time(player,games[10],created=created_time,updated=dt.datetime(2013,8,10))
         self.assertEqual(self.calc.get_player_submit_time(player),dt.datetime(2013,8,11))
 
-    # BLR - This test may not be valid
-    def __t36_week_lock_picks_not_specified(self):
+    def __t36_week_pick_deadline_not_specified(self):
         player = self.week1.get_player("Brent Holden")
         games = self.week1.games
         week = self.week1.week
-        week.lock_picks = True
-        week.pick_deadline = dt.datetime(2013,8,12)
+        week.pick_deadline = None
         created_time=dt.datetime(2013,8,1)
         updated_time=dt.datetime(2013,8,10)
         self.__change_player_pick_time(player,games[1],created=created_time,updated=updated_time)
@@ -2621,7 +2619,7 @@ class CalculatorTests(TestCase):
         self.__change_player_pick_time(player,games[10],created=created_time,updated=updated_time)
         self.assertIsNone(self.calc.get_player_submit_time(player,week))
 
-    def __t36_submit_after_week_lock(self):
+    def __t36_submit_after_week_deadline(self):
         player = self.week1.get_player("Brent Holden")
         games = self.week1.games
         week = self.week1.week
@@ -2641,7 +2639,7 @@ class CalculatorTests(TestCase):
         self.__change_player_pick_time(player,games[10],created=created_time,updated=updated_time)
         self.assertIsNone(self.calc.get_player_submit_time(player,week))
 
-    def __t36_submit_before_week_lock(self):
+    def __t36_submit_before_week_deadline(self):
         player = self.week1.get_player("Brent Holden")
         games = self.week1.games
         week = self.week1.week
@@ -2660,7 +2658,7 @@ class CalculatorTests(TestCase):
         self.__change_player_pick_time(player,games[10],created=created_time,updated=dt.datetime(2013,8,10))
         self.assertEqual(self.calc.get_player_submit_time(player,week),dt.datetime(2013,8,11))
 
-    def __t36_submit_same_as_week_lock(self):
+    def __t36_submit_same_as_week_deadline(self):
         player = self.week1.get_player("Brent Holden")
         games = self.week1.games
         week = self.week1.week

--- a/pick10/week_winner.py
+++ b/pick10/week_winner.py
@@ -360,7 +360,7 @@ class WeekWinner:
         return self.tiebreaker_2_unnecessary() or one_player_won_tiebreak2
 
     # tiebreaker 3 is valid when: 
-    # - week.lock_picks is set (i.e a pick deadline set)
+    # - week.pick_deadline is set (i.e a pick deadline set)
     # - the picks were entered before the pick deadline
     # - the submit time makes sense (i.e. submit time year matches the week.year)
     # TODO:  consider adding a pick submit time to Picks data model?

--- a/templates/pick10/enter_picks_error.html
+++ b/templates/pick10/enter_picks_error.html
@@ -21,6 +21,9 @@
         <div id="error-msg">Player {{player_id}} does not match the logged in user.</div>
         <div id="error-msg">A user can only access their own enter picks page.</div>
     {% endif %}
+    {% if error == "picks_locked" %}
+        <div id="error-msg">Picks are currently locked and cannot be entered.</div>
+    {% endif %}
     {% if error == "after_pick_deadline" %}
         <div id="error-msg">Pick deadline: {{deadline}}.</div><br>
         <div id="error-msg">The pick deadline has expired.  Picks can no longer be entered.</div>


### PR DESCRIPTION
This update fixes the code to use the new Week.lock_picks and Week.pick_deadline correctly (#69).  This includes checking for locked picks in the "Enter Picks" page and displaying an error message if picks are locked.