### PR TITLE
removed offset columns from body column

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -57,7 +57,7 @@
             <div class="col-sm-3 col-md-2">
                 {% block side_block %}{% endblock %}
             </div>
-            <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
+            <div class="col-sm-9 col-md-10 main">
                 <div>
                     <h1 id="base_id">College Football Pick 10</h1>
                     {% block body_header_block %}{% endblock %}


### PR DESCRIPTION
I think I've fixed issue #57.  Here is an image after the change.

![screen shot 2015-08-29 at 9 15 50 pm](https://cloud.githubusercontent.com/assets/1541768/9565275/99fd17ce-4e93-11e5-9053-e97b69abc8c5.png)

I removed the offset column (look at the diff).  I think that the offset would only be used if you didn't have the sidebar column and wanted to move it over some offset.