### PR TITLE
Import week

### DIFF
--- a/stage_history.py
+++ b/stage_history.py
@@ -234,5 +234,5 @@ def main(years=None, weeks=None, verbose=False):
 
 # Execution starts here
 if __name__ == '__main__':
-    main(years=[2015])
+    main()
 


### PR DESCRIPTION
This branch will load the data from the spreadsheet at the start of the week (i.e. no games scores yet).
Just run the stage_history.py script with the week to add.  (example:  main(years=[2015],weeks=[1])).  I'm not sure if you want to keep all of this code or not.  A few issues:

**new players**
New players in the pool this year are not in the player_username dict in spreadsheet_test.py.  As a fix, in convert_to_private_name() and convert_to_public_name(), the code determines the first name and lastname from the ssplayername instead if the name is not in player_username dict. I'm not sure this is the behavior you want or not.

**adding games for the week**
This code was modified to add games with no scores in the spreadsheet as a NOT_STARTED game with actualpoints set to -1, and winner=0.  Also, the week.lock_scores is set to false.  I think this code is probably ok.

**TODO:**  some routine needs to be written to update the game scores at the end of the week