### PR TITLE
No picks

### DIFF
--- a/excel_picks.py
+++ b/excel_picks.py
@@ -63,6 +63,12 @@ def print_all_player_picks(data):
 
 def get_picks_column(player_id,data):
     player = data.players[player_id]
+
+    no_picks = player.id not in data.player_picks
+    if no_picks:
+        column = [''] * 12
+        return column
+
     picks = { pick.game.gamenum:pick for pick in data.player_picks[player_id] }
 
     column = []

--- a/functional_tests/test_no_picks.py
+++ b/functional_tests/test_no_picks.py
@@ -271,11 +271,162 @@ class NoPicksTest(FunctionalTest):
         test_db.delete_database()
 
 
+    @unittest.skip('tested')
     def test_week_results_week2_in_progress_player2(self):
         # login player with no picks
         test_db = UnitTestDatabase()
         test_db.setup_week_final(1978,1)
         test_db.setup_week_in_progress_with_no_pick_defaulters(1978,2)
+        self.__login_player('John',1978)
+
+        player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
+        player_no_picks = self.utils.get_player_from_public_name(1978,'John')
+
+        self.utils.week_results_page(1978,1)
+        self.__is_page_up('Week 1 Leaderboard')
+
+        self.utils.week_results_page(1978,2)
+        self.__is_page_up('Week 2 Leaderboard')
+
+        self.utils.overall_results_page(1978)
+        self.__is_page_up('1978 Leaderboard')
+
+        self.utils.player_results_page(1978,1,player_with_picks.id)
+        self.__is_page_up('Brent Week 1 Results')
+
+        self.utils.player_results_page(1978,2,player_with_picks.id)
+        self.__is_page_up('Brent Week 2 Results')
+
+        self.utils.player_results_page(1978,1,player_no_picks.id)
+        self.__is_page_up('John Week 1 Results')
+
+        self.utils.player_results_page(1978,2,player_no_picks.id)
+        self.__is_page_up('John Week 2 Results')
+
+        self.utils.enter_picks_page(1978,1,player_no_picks.id)
+        self.__is_page_up('The week is final')
+
+        self.utils.enter_picks_page(1978,2,player_no_picks.id)
+        self.__is_page_up('The week is currently in progress')
+
+        self.utils.update_games_page(1978,1)
+        self.__is_page_up('Week 1 Games')
+
+        self.utils.update_games_page(1978,2)
+        self.__is_page_up('Week 2 Games')
+
+        test_db.delete_database()
+
+    @unittest.skip('tested')
+    def test_week_results_week1_final(self):
+        test_db = UnitTestDatabase()
+        test_db.setup_week_final_with_no_pick_defaulters(1978,1)
+        self.__login_player('Brent',1978)
+
+        player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
+        player_no_picks = self.utils.get_player_from_public_name(1978,'John')
+
+        self.utils.week_results_page(1978,1)
+        self.__is_page_up('Week 1 Leaderboard')
+
+        self.utils.overall_results_page(1978)
+        self.__is_page_up('1978 Leaderboard')
+
+        self.utils.player_results_page(1978,1,player_with_picks.id)
+        self.__is_page_up('Brent Week 1 Results')
+
+        self.utils.player_results_page(1978,1,player_no_picks.id)
+        self.__is_page_up('John Week 1 Results')
+
+        self.utils.enter_picks_page(1978,1,player_with_picks.id)
+        self.__is_page_up('The week is final')
+
+        self.utils.update_games_page(1978,1)
+        self.__is_page_up('Week 1 Games')
+
+        test_db.delete_database()
+
+    @unittest.skip('tested')
+    def test_week_results_week2_final(self):
+        test_db = UnitTestDatabase()
+        test_db.setup_week_final(1978,1)
+        test_db.setup_week_final_with_no_pick_defaulters(1978,2)
+        self.__login_player('Brent',1978)
+
+        player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
+        player_no_picks = self.utils.get_player_from_public_name(1978,'John')
+
+        self.utils.week_results_page(1978,1)
+        self.__is_page_up('Week 1 Leaderboard')
+
+        self.utils.week_results_page(1978,2)
+        self.__is_page_up('Week 2 Leaderboard')
+
+        self.utils.overall_results_page(1978)
+        self.__is_page_up('1978 Leaderboard')
+
+        self.utils.player_results_page(1978,1,player_with_picks.id)
+        self.__is_page_up('Brent Week 1 Results')
+
+        self.utils.player_results_page(1978,2,player_with_picks.id)
+        self.__is_page_up('Brent Week 2 Results')
+
+        self.utils.player_results_page(1978,1,player_no_picks.id)
+        self.__is_page_up('John Week 1 Results')
+
+        self.utils.player_results_page(1978,2,player_no_picks.id)
+        self.__is_page_up('John Week 2 Results')
+
+        self.utils.enter_picks_page(1978,1,player_with_picks.id)
+        self.__is_page_up('The week is final')
+
+        self.utils.enter_picks_page(1978,2,player_with_picks.id)
+        self.__is_page_up('The week is final')
+
+        self.utils.update_games_page(1978,1)
+        self.__is_page_up('Week 1 Games')
+
+        self.utils.update_games_page(1978,2)
+        self.__is_page_up('Week 2 Games')
+
+        test_db.delete_database()
+
+    @unittest.skip('tested')
+    def test_week_results_week1_final_player2(self):
+        # login player with no picks
+        test_db = UnitTestDatabase()
+        test_db.setup_week_final_with_no_pick_defaulters(1978,1)
+        self.__login_player('John',1978)
+
+        player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
+        player_no_picks = self.utils.get_player_from_public_name(1978,'John')
+
+        self.utils.week_results_page(1978,1)
+        self.__is_page_up('Week 1 Leaderboard')
+
+        self.utils.overall_results_page(1978)
+        self.__is_page_up('1978 Leaderboard')
+
+        self.utils.player_results_page(1978,1,player_with_picks.id)
+        self.__is_page_up('Brent Week 1 Results')
+
+        self.utils.player_results_page(1978,1,player_no_picks.id)
+        self.__is_page_up('John Week 1 Results')
+
+        self.utils.enter_picks_page(1978,1,player_no_picks.id)
+        self.__is_page_up('The week is final')
+
+        self.utils.update_games_page(1978,1)
+        self.__is_page_up('Week 1 Games')
+
+        test_db.delete_database()
+
+
+    def test_week_results_week2_final_player2(self):
+        # login player with no picks
+        test_db = UnitTestDatabase()
+        test_db.setup_week_final(1978,1)
+        test_db.setup_week_final_with_no_pick_defaulters(1978,2)
         self.__login_player('John',1978)
 
         player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
@@ -307,7 +458,7 @@ class NoPicksTest(FunctionalTest):
         self.__is_page_up('The week is final')
 
         self.utils.enter_picks_page(1978,2,player_no_picks.id)
-        self.__is_page_up('The week is currently in progress')
+        self.__is_page_up('The week is final')
 
         self.utils.update_games_page(1978,1)
         self.__is_page_up('Week 1 Games')

--- a/functional_tests/test_no_picks.py
+++ b/functional_tests/test_no_picks.py
@@ -120,6 +120,7 @@ class NoPicksTest(FunctionalTest):
         test_db.delete_database()
 
 
+    @unittest.skip('tested')
     def test_week_results_week2_not_started_player2(self):
         # login player with no picks
         test_db = UnitTestDatabase()
@@ -156,6 +157,157 @@ class NoPicksTest(FunctionalTest):
 
         self.utils.enter_picks_page(1978,2,player_no_picks.id)
         self.__is_page_up('John Week 2 Picks')
+
+        self.utils.update_games_page(1978,1)
+        self.__is_page_up('Week 1 Games')
+
+        self.utils.update_games_page(1978,2)
+        self.__is_page_up('Week 2 Games')
+
+        test_db.delete_database()
+
+    @unittest.skip('tested')
+    def test_week_results_week1_in_progress(self):
+        test_db = UnitTestDatabase()
+        test_db.setup_week_in_progress_with_no_pick_defaulters(1978,1)
+        self.__login_player('Brent',1978)
+
+        player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
+        player_no_picks = self.utils.get_player_from_public_name(1978,'John')
+
+        self.utils.week_results_page(1978,1)
+        self.__is_page_up('Week 1 Leaderboard')
+
+        self.utils.overall_results_page(1978)
+        self.__is_page_up('1978 Leaderboard')
+
+        self.utils.player_results_page(1978,1,player_with_picks.id)
+        self.__is_page_up('Brent Week 1 Results')
+
+        self.utils.player_results_page(1978,1,player_no_picks.id)
+        self.__is_page_up('John Week 1 Results')
+
+        self.utils.enter_picks_page(1978,1,player_with_picks.id)
+        self.__is_page_up('The week is currently in progress')
+
+        self.utils.update_games_page(1978,1)
+        self.__is_page_up('Week 1 Games')
+
+        test_db.delete_database()
+
+    @unittest.skip('tested')
+    def test_week_results_week2_in_progress(self):
+        test_db = UnitTestDatabase()
+        test_db.setup_week_final(1978,1)
+        test_db.setup_week_in_progress_with_no_pick_defaulters(1978,2)
+        self.__login_player('Brent',1978)
+
+        player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
+        player_no_picks = self.utils.get_player_from_public_name(1978,'John')
+
+        self.utils.week_results_page(1978,1)
+        self.__is_page_up('Week 1 Leaderboard')
+
+        self.utils.week_results_page(1978,2)
+        self.__is_page_up('Week 2 Leaderboard')
+
+        self.utils.overall_results_page(1978)
+        self.__is_page_up('1978 Leaderboard')
+
+        self.utils.player_results_page(1978,1,player_with_picks.id)
+        self.__is_page_up('Brent Week 1 Results')
+
+        self.utils.player_results_page(1978,2,player_with_picks.id)
+        self.__is_page_up('Brent Week 2 Results')
+
+        self.utils.player_results_page(1978,1,player_no_picks.id)
+        self.__is_page_up('John Week 1 Results')
+
+        self.utils.player_results_page(1978,2,player_no_picks.id)
+        self.__is_page_up('John Week 2 Results')
+
+        self.utils.enter_picks_page(1978,1,player_with_picks.id)
+        self.__is_page_up('The week is final')
+
+        self.utils.enter_picks_page(1978,2,player_with_picks.id)
+        self.__is_page_up('The week is currently in progress')
+
+        self.utils.update_games_page(1978,1)
+        self.__is_page_up('Week 1 Games')
+
+        self.utils.update_games_page(1978,2)
+        self.__is_page_up('Week 2 Games')
+
+        test_db.delete_database()
+
+    @unittest.skip('tested')
+    def test_week_results_week1_in_progress_player2(self):
+        # login player with no picks
+        test_db = UnitTestDatabase()
+        test_db.setup_week_in_progress_with_no_pick_defaulters(1978,1)
+        self.__login_player('John',1978)
+
+        player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
+        player_no_picks = self.utils.get_player_from_public_name(1978,'John')
+
+        self.utils.week_results_page(1978,1)
+        self.__is_page_up('Week 1 Leaderboard')
+
+        self.utils.overall_results_page(1978)
+        self.__is_page_up('1978 Leaderboard')
+
+        self.utils.player_results_page(1978,1,player_with_picks.id)
+        self.__is_page_up('Brent Week 1 Results')
+
+        self.utils.player_results_page(1978,1,player_no_picks.id)
+        self.__is_page_up('John Week 1 Results')
+
+        self.utils.enter_picks_page(1978,1,player_no_picks.id)
+        self.__is_page_up('The week is currently in progress')
+
+        self.utils.update_games_page(1978,1)
+        self.__is_page_up('Week 1 Games')
+
+        test_db.delete_database()
+
+
+    def test_week_results_week2_in_progress_player2(self):
+        # login player with no picks
+        test_db = UnitTestDatabase()
+        test_db.setup_week_final(1978,1)
+        test_db.setup_week_in_progress_with_no_pick_defaulters(1978,2)
+        self.__login_player('John',1978)
+
+        player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
+        player_no_picks = self.utils.get_player_from_public_name(1978,'John')
+
+        import pdb; pdb.set_trace()
+        self.utils.week_results_page(1978,1)
+        self.__is_page_up('Week 1 Leaderboard')
+
+        self.utils.week_results_page(1978,2)
+        self.__is_page_up('Week 2 Leaderboard')
+
+        self.utils.overall_results_page(1978)
+        self.__is_page_up('1978 Leaderboard')
+
+        self.utils.player_results_page(1978,1,player_with_picks.id)
+        self.__is_page_up('Brent Week 1 Results')
+
+        self.utils.player_results_page(1978,2,player_with_picks.id)
+        self.__is_page_up('Brent Week 2 Results')
+
+        self.utils.player_results_page(1978,1,player_no_picks.id)
+        self.__is_page_up('John Week 1 Results')
+
+        self.utils.player_results_page(1978,2,player_no_picks.id)
+        self.__is_page_up('John Week 2 Results')
+
+        self.utils.enter_picks_page(1978,1,player_no_picks.id)
+        self.__is_page_up('The week is final')
+
+        self.utils.enter_picks_page(1978,2,player_no_picks.id)
+        self.__is_page_up('The week is currently in progress')
 
         self.utils.update_games_page(1978,1)
         self.__is_page_up('Week 1 Games')

--- a/functional_tests/test_no_picks.py
+++ b/functional_tests/test_no_picks.py
@@ -456,6 +456,22 @@ class NoPicksTest(FunctionalTest):
 
         test_db.delete_database()
 
+    def test_tiebreak_0_special_case(self):
+        # login player with no picks
+        test_db = UnitTestDatabase()
+        test_db.setup_week_final(1978,1)
+        test_db.setup_week_no_picks(1978,2,FINAL)
+        self.__login_player('Brent',1978)
+
+        player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
+        player_no_picks = self.utils.get_player_from_public_name(1978,'John')
+
+        import pdb; pdb.set_trace()
+        self.utils.tiebreak_page(1978,2)
+        self.__is_page_up('Week 2 Tiebreak')
+
+        test_db.delete_database()
+
     def __login_player(self,name,year):
         player = self.utils.get_player_from_public_name(year,name)
         self.utils.login_assigned_user(name=name,player=player)

--- a/functional_tests/test_no_picks.py
+++ b/functional_tests/test_no_picks.py
@@ -456,7 +456,7 @@ class NoPicksTest(FunctionalTest):
 
         test_db.delete_database()
 
-    def test_tiebreak_0_special_case(self):
+    def test_tiebreak_special_case(self):
         # login player with no picks
         test_db = UnitTestDatabase()
         test_db.setup_week_final(1978,1)

--- a/functional_tests/test_no_picks.py
+++ b/functional_tests/test_no_picks.py
@@ -15,7 +15,6 @@ class NoPicksTest(FunctionalTest):
         super(NoPicksTest, self).setUp()
         self.utils = Utils(self.browser,self.server_url)
 
-    @unittest.skip('tested')
     def test_week_results_week1_not_started(self):
         test_db = UnitTestDatabase()
         test_db.setup_week_not_started_with_no_pick_defaulters(1978,1)
@@ -44,7 +43,6 @@ class NoPicksTest(FunctionalTest):
 
         test_db.delete_database()
 
-    @unittest.skip('tested')
     def test_week_results_week2_not_started(self):
         test_db = UnitTestDatabase()
         test_db.setup_week_final(1978,1)
@@ -89,7 +87,6 @@ class NoPicksTest(FunctionalTest):
 
         test_db.delete_database()
 
-    @unittest.skip('tested')
     def test_week_results_week1_not_started_player2(self):
         # login player with no picks
         test_db = UnitTestDatabase()
@@ -120,7 +117,6 @@ class NoPicksTest(FunctionalTest):
         test_db.delete_database()
 
 
-    @unittest.skip('tested')
     def test_week_results_week2_not_started_player2(self):
         # login player with no picks
         test_db = UnitTestDatabase()
@@ -166,7 +162,6 @@ class NoPicksTest(FunctionalTest):
 
         test_db.delete_database()
 
-    @unittest.skip('tested')
     def test_week_results_week1_in_progress(self):
         test_db = UnitTestDatabase()
         test_db.setup_week_in_progress_with_no_pick_defaulters(1978,1)
@@ -195,7 +190,6 @@ class NoPicksTest(FunctionalTest):
 
         test_db.delete_database()
 
-    @unittest.skip('tested')
     def test_week_results_week2_in_progress(self):
         test_db = UnitTestDatabase()
         test_db.setup_week_final(1978,1)
@@ -240,7 +234,6 @@ class NoPicksTest(FunctionalTest):
 
         test_db.delete_database()
 
-    @unittest.skip('tested')
     def test_week_results_week1_in_progress_player2(self):
         # login player with no picks
         test_db = UnitTestDatabase()
@@ -271,7 +264,6 @@ class NoPicksTest(FunctionalTest):
         test_db.delete_database()
 
 
-    @unittest.skip('tested')
     def test_week_results_week2_in_progress_player2(self):
         # login player with no picks
         test_db = UnitTestDatabase()
@@ -317,7 +309,6 @@ class NoPicksTest(FunctionalTest):
 
         test_db.delete_database()
 
-    @unittest.skip('tested')
     def test_week_results_week1_final(self):
         test_db = UnitTestDatabase()
         test_db.setup_week_final_with_no_pick_defaulters(1978,1)
@@ -346,7 +337,6 @@ class NoPicksTest(FunctionalTest):
 
         test_db.delete_database()
 
-    @unittest.skip('tested')
     def test_week_results_week2_final(self):
         test_db = UnitTestDatabase()
         test_db.setup_week_final(1978,1)
@@ -391,7 +381,6 @@ class NoPicksTest(FunctionalTest):
 
         test_db.delete_database()
 
-    @unittest.skip('tested')
     def test_week_results_week1_final_player2(self):
         # login player with no picks
         test_db = UnitTestDatabase()
@@ -432,7 +421,6 @@ class NoPicksTest(FunctionalTest):
         player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
         player_no_picks = self.utils.get_player_from_public_name(1978,'John')
 
-        import pdb; pdb.set_trace()
         self.utils.week_results_page(1978,1)
         self.__is_page_up('Week 1 Leaderboard')
 

--- a/functional_tests/test_no_picks.py
+++ b/functional_tests/test_no_picks.py
@@ -15,6 +15,7 @@ class NoPicksTest(FunctionalTest):
         super(NoPicksTest, self).setUp()
         self.utils = Utils(self.browser,self.server_url)
 
+    @unittest.skip('tested')
     def test_week_results_week1_not_started(self):
         test_db = UnitTestDatabase()
         test_db.setup_week_not_started_with_no_pick_defaulters(1978,1)
@@ -23,30 +24,151 @@ class NoPicksTest(FunctionalTest):
         player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
         player_no_picks = self.utils.get_player_from_public_name(1978,'John')
 
-        import pdb; pdb.set_trace()
         self.utils.week_results_page(1978,1)
+        self.__is_page_up('Week 1 Leaderboard')
+
         self.utils.overall_results_page(1978)
+        self.__is_page_up('1978 Leaderboard')
+
         self.utils.player_results_page(1978,1,player_with_picks.id)
+        self.__is_page_up('Brent Week 1 Results')
+
         self.utils.player_results_page(1978,1,player_no_picks.id)
+        self.__is_page_up('John Week 1 Results')
+
         self.utils.enter_picks_page(1978,1,player_with_picks.id)
+        self.__is_page_up('Brent Week 1 Picks')
+
         self.utils.update_games_page(1978,1)
+        self.__is_page_up('Week 1 Games')
 
         test_db.delete_database()
 
-    @unittest.skip('not yet')
+    @unittest.skip('tested')
     def test_week_results_week2_not_started(self):
-        self.fail('not implemented yet')
+        test_db = UnitTestDatabase()
+        test_db.setup_week_final(1978,1)
+        test_db.setup_week_not_started_with_no_pick_defaulters(1978,2)
+        self.__login_player('Brent',1978)
 
-    @unittest.skip('not yet')
+        player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
+        player_no_picks = self.utils.get_player_from_public_name(1978,'John')
+
+        self.utils.week_results_page(1978,1)
+        self.__is_page_up('Week 1 Leaderboard')
+
+        self.utils.week_results_page(1978,2)
+        self.__is_page_up('Week 2 Leaderboard')
+
+        self.utils.overall_results_page(1978)
+        self.__is_page_up('1978 Leaderboard')
+
+        self.utils.player_results_page(1978,1,player_with_picks.id)
+        self.__is_page_up('Brent Week 1 Results')
+
+        self.utils.player_results_page(1978,2,player_with_picks.id)
+        self.__is_page_up('Brent Week 2 Results')
+
+        self.utils.player_results_page(1978,1,player_no_picks.id)
+        self.__is_page_up('John Week 1 Results')
+
+        self.utils.player_results_page(1978,2,player_no_picks.id)
+        self.__is_page_up('John Week 2 Results')
+
+        self.utils.enter_picks_page(1978,1,player_with_picks.id)
+        self.__is_page_up('The week is final')
+
+        self.utils.enter_picks_page(1978,2,player_with_picks.id)
+        self.__is_page_up('Brent Week 2 Picks')
+
+        self.utils.update_games_page(1978,1)
+        self.__is_page_up('Week 1 Games')
+
+        self.utils.update_games_page(1978,2)
+        self.__is_page_up('Week 2 Games')
+
+        test_db.delete_database()
+
+    @unittest.skip('tested')
     def test_week_results_week1_not_started_player2(self):
         # login player with no picks
-        self.fail('not implemented yet')
+        test_db = UnitTestDatabase()
+        test_db.setup_week_not_started_with_no_pick_defaulters(1978,1)
+        self.__login_player('John',1978)
 
-    @unittest.skip('not yet')
+        player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
+        player_no_picks = self.utils.get_player_from_public_name(1978,'John')
+
+        self.utils.week_results_page(1978,1)
+        self.__is_page_up('Week 1 Leaderboard')
+
+        self.utils.overall_results_page(1978)
+        self.__is_page_up('1978 Leaderboard')
+
+        self.utils.player_results_page(1978,1,player_with_picks.id)
+        self.__is_page_up('Brent Week 1 Results')
+
+        self.utils.player_results_page(1978,1,player_no_picks.id)
+        self.__is_page_up('John Week 1 Results')
+
+        self.utils.enter_picks_page(1978,1,player_no_picks.id)
+        self.__is_page_up('John Week 1 Picks')
+
+        self.utils.update_games_page(1978,1)
+        self.__is_page_up('Week 1 Games')
+
+        test_db.delete_database()
+
+
     def test_week_results_week2_not_started_player2(self):
         # login player with no picks
-        self.fail('not implemented yet')
+        test_db = UnitTestDatabase()
+        test_db.setup_week_final(1978,1)
+        test_db.setup_week_not_started_with_no_pick_defaulters(1978,2)
+        self.__login_player('John',1978)
+
+        player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
+        player_no_picks = self.utils.get_player_from_public_name(1978,'John')
+
+        self.utils.week_results_page(1978,1)
+        self.__is_page_up('Week 1 Leaderboard')
+
+        self.utils.week_results_page(1978,2)
+        self.__is_page_up('Week 2 Leaderboard')
+
+        self.utils.overall_results_page(1978)
+        self.__is_page_up('1978 Leaderboard')
+
+        self.utils.player_results_page(1978,1,player_with_picks.id)
+        self.__is_page_up('Brent Week 1 Results')
+
+        self.utils.player_results_page(1978,2,player_with_picks.id)
+        self.__is_page_up('Brent Week 2 Results')
+
+        self.utils.player_results_page(1978,1,player_no_picks.id)
+        self.__is_page_up('John Week 1 Results')
+
+        self.utils.player_results_page(1978,2,player_no_picks.id)
+        self.__is_page_up('John Week 2 Results')
+
+        self.utils.enter_picks_page(1978,1,player_no_picks.id)
+        self.__is_page_up('The week is final')
+
+        self.utils.enter_picks_page(1978,2,player_no_picks.id)
+        self.__is_page_up('John Week 2 Picks')
+
+        self.utils.update_games_page(1978,1)
+        self.__is_page_up('Week 1 Games')
+
+        self.utils.update_games_page(1978,2)
+        self.__is_page_up('Week 2 Games')
+
+        test_db.delete_database()
 
     def __login_player(self,name,year):
         player = self.utils.get_player_from_public_name(year,name)
         self.utils.login_assigned_user(name=name,player=player)
+
+    def __is_page_up(self,text):
+        body = self.browser.find_element_by_tag_name('body').text
+        self.assertIn(text,body)

--- a/functional_tests/test_no_picks.py
+++ b/functional_tests/test_no_picks.py
@@ -1,0 +1,52 @@
+from .base import FunctionalTest
+from django.core.urlresolvers import reverse
+from pick10.tests.unit_test_database import *
+import unittest
+from django.core.cache import *
+from utils import *
+from django.conf import settings
+
+class NoPicksTest(FunctionalTest):
+
+    def setUp(self):
+        settings.DEBUG = True
+        cache = get_cache('default')
+        cache.clear()
+        super(NoPicksTest, self).setUp()
+        self.utils = Utils(self.browser,self.server_url)
+
+    def test_week_results_week1_not_started(self):
+        test_db = UnitTestDatabase()
+        test_db.setup_week_not_started_with_no_pick_defaulters(1978,1)
+        self.__login_player('Brent',1978)
+
+        player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
+        player_no_picks = self.utils.get_player_from_public_name(1978,'John')
+
+        import pdb; pdb.set_trace()
+        self.utils.week_results_page(1978,1)
+        self.utils.overall_results_page(1978)
+        self.utils.player_results_page(1978,1,player_with_picks.id)
+        self.utils.player_results_page(1978,1,player_no_picks.id)
+        self.utils.enter_picks_page(1978,1,player_with_picks.id)
+        self.utils.update_games_page(1978,1)
+
+        test_db.delete_database()
+
+    @unittest.skip('not yet')
+    def test_week_results_week2_not_started(self):
+        self.fail('not implemented yet')
+
+    @unittest.skip('not yet')
+    def test_week_results_week1_not_started_player2(self):
+        # login player with no picks
+        self.fail('not implemented yet')
+
+    @unittest.skip('not yet')
+    def test_week_results_week2_not_started_player2(self):
+        # login player with no picks
+        self.fail('not implemented yet')
+
+    def __login_player(self,name,year):
+        player = self.utils.get_player_from_public_name(year,name)
+        self.utils.login_assigned_user(name=name,player=player)

--- a/functional_tests/test_no_picks.py
+++ b/functional_tests/test_no_picks.py
@@ -466,9 +466,8 @@ class NoPicksTest(FunctionalTest):
         player_with_picks = self.utils.get_player_from_public_name(1978,'Brent')
         player_no_picks = self.utils.get_player_from_public_name(1978,'John')
 
-        import pdb; pdb.set_trace()
         self.utils.tiebreak_page(1978,2)
-        self.__is_page_up('Week 2 Tiebreak')
+        self.__is_page_up('Week 2 Tiebreaker')
 
         test_db.delete_database()
 

--- a/pick10/calculate_player_results.py
+++ b/pick10/calculate_player_results.py
@@ -87,11 +87,16 @@ class CalculatePlayerResults:
         return result
 
     def __set_game10_attributes(self,summary):
-        team1_score,team2_score = self.__get_player_game10_pick_score()
-        summary.game10_predicted_team1_score = team1_score
-        summary.game10_predicted_team2_score = team2_score
-        
         game10 = self.__calc.get_featured_game()
+
+        if self.__calc.player_did_not_pick(self.__player,game10):
+            summary.game10_predicted_team1_score = 'n/a'
+            summary.game10_predicted_team2_score = 'n/a'
+        else:
+            team1_score,team2_score = self.__get_player_game10_pick_score()
+            summary.game10_predicted_team1_score = team1_score
+            summary.game10_predicted_team2_score = team2_score
+
         summary.game10_team1 = game10.team1.team_name
         summary.game10_team2 = game10.team2.team_name
 

--- a/pick10/calculate_tiebreak.py
+++ b/pick10/calculate_tiebreak.py
@@ -175,10 +175,15 @@ class CalculateTiebreak:
                 d = Tiebreak0Data()
                 d.player_id = player_id
                 d.player_name = self.__get_player_name(player_id)
-                d.player_pick = self.__calc.get_team_name_player_picked_to_win(player,featured_game)
                 d.result = result
                 d.result_id = css_id
                 d.featured_game_winner = self.__get_featured_game_winner()
+
+                if self.__calc.player_did_not_pick(player,featured_game):
+                    d.player_pick = 'n/a'
+                else:
+                    d.player_pick = self.__calc.get_team_name_player_picked_to_win(player,featured_game)
+
                 details.append(d)
 
         players = self.__winners.get_players_that_lost_tiebreak_0()
@@ -192,10 +197,15 @@ class CalculateTiebreak:
                 d = Tiebreak0Data()
                 d.player_id = player_id
                 d.player_name = self.__get_player_name(player_id)
-                d.player_pick = self.__calc.get_team_name_player_picked_to_win(player,featured_game)
                 d.result = result
                 d.result_id = css_id
                 d.featured_game_winner = self.__get_featured_game_winner()
+
+                if self.__calc.player_did_not_pick(player,featured_game):
+                    d.player_pick = 'n/a'
+                else:
+                    d.player_pick = self.__calc.get_team_name_player_picked_to_win(player,featured_game)
+
                 details.append(d)
 
         self.__tiebreak0_details = self.__sort_tiebreak0(details)
@@ -232,12 +242,17 @@ class CalculateTiebreak:
                 d.result = result
                 d.result_id = css_id
     
-                pick = self.__calc.get_player_pick_for_game(player,featured_game)
-    
-                d.team1_score = pick.team1_predicted_points
-                d.team2_score = pick.team2_predicted_points
-                d.pick_spread = pick.team1_predicted_points - pick.team2_predicted_points
-                d.difference = abs(d.pick_spread - summary.result_spread)
+                if self.__calc.player_did_not_pick(player,featured_game):
+                    d.team1_score = 'n/a'
+                    d.team2_score = 'n/a'
+                    d.pick_spread = 'n/a'
+                    d.difference = 'n/a'
+                else:
+                    pick = self.__calc.get_player_pick_for_game(player,featured_game)
+                    d.team1_score = pick.team1_predicted_points
+                    d.team2_score = pick.team2_predicted_points
+                    d.pick_spread = pick.team1_predicted_points - pick.team2_predicted_points
+                    d.difference = abs(d.pick_spread - summary.result_spread)
     
                 details.append(d)
 
@@ -254,13 +269,18 @@ class CalculateTiebreak:
                 d.player_name = self.__get_player_name(player_id)
                 d.result = result
                 d.result_id = css_id
-        
-                pick = self.__calc.get_player_pick_for_game(player,featured_game)
 
-                d.team1_score = pick.team1_predicted_points
-                d.team2_score = pick.team2_predicted_points
-                d.pick_spread = pick.team1_predicted_points - pick.team2_predicted_points
-                d.difference = abs(d.pick_spread - summary.result_spread)
+                if self.__calc.player_did_not_pick(player,featured_game):
+                    d.team1_score = 'n/a'
+                    d.team2_score = 'n/a'
+                    d.pick_spread = 'n/a'
+                    d.difference = 'n/a'
+                else:
+                    pick = self.__calc.get_player_pick_for_game(player,featured_game)
+                    d.team1_score = pick.team1_predicted_points
+                    d.team2_score = pick.team2_predicted_points
+                    d.pick_spread = pick.team1_predicted_points - pick.team2_predicted_points
+                    d.difference = abs(d.pick_spread - summary.result_spread)
 
                 details.append(d)
 
@@ -299,12 +319,17 @@ class CalculateTiebreak:
                 d.result = result
                 d.result_id = css_id
     
-                pick = self.__calc.get_player_pick_for_game(player,featured_game)
-    
-                d.team1_score = pick.team1_predicted_points
-                d.team2_score = pick.team2_predicted_points
-                d.pick_total = pick.team1_predicted_points + pick.team2_predicted_points
-                d.difference = abs(summary.result_total - d.pick_total)
+                if self.__calc.player_did_not_pick(player,featured_game):
+                    d.team1_score = 'n/a'
+                    d.team2_score = 'n/a'
+                    d.pick_total = 'n/a'
+                    d.difference = 'n/a'
+                else:
+                    pick = self.__calc.get_player_pick_for_game(player,featured_game)
+                    d.team1_score = pick.team1_predicted_points
+                    d.team2_score = pick.team2_predicted_points
+                    d.pick_total = pick.team1_predicted_points + pick.team2_predicted_points
+                    d.difference = abs(summary.result_total - d.pick_total)
     
                 details.append(d)
 
@@ -322,12 +347,17 @@ class CalculateTiebreak:
                 d.result = result
                 d.result_id = css_id
     
-                pick = self.__calc.get_player_pick_for_game(player,featured_game)
-    
-                d.team1_score = pick.team1_predicted_points
-                d.team2_score = pick.team2_predicted_points
-                d.pick_total = pick.team1_predicted_points + pick.team2_predicted_points
-                d.difference = abs(summary.result_total - d.pick_total)
+                if self.__calc.player_did_not_pick(player,featured_game):
+                    d.team1_score = 'n/a'
+                    d.team2_score = 'n/a'
+                    d.pick_total = 'n/a'
+                    d.difference = 'n/a'
+                else:
+                    pick = self.__calc.get_player_pick_for_game(player,featured_game)
+                    d.team1_score = pick.team1_predicted_points
+                    d.team2_score = pick.team2_predicted_points
+                    d.pick_total = pick.team1_predicted_points + pick.team2_predicted_points
+                    d.difference = abs(summary.result_total - d.pick_total)
 
                 details.append(d)
 
@@ -508,17 +538,20 @@ class CalculateTiebreak:
         sort_by_name = sorted(details,key=lambda item:item.player_name)
         sort_by_wins = sorted(sort_by_name,key=lambda item:item.result == "won",reverse=True)
         sort_by_ahead = sorted(sort_by_wins,key=lambda item:item.result == "ahead",reverse=True)
-        return sort_by_ahead
+        move_na_to_end = sorted(sort_by_ahead,key=lambda item:item.player_pick != 'n/a',reverse=True)
+        return move_na_to_end
 
     def __sort_tiebreak1(self,details):
         sort_by_name = sorted(details,key=lambda item:item.player_name)
         sort_by_difference = sorted(sort_by_name,key=lambda item:item.difference)
-        return sort_by_difference
+        move_na_to_end = sorted(sort_by_difference,key=lambda item:item.difference != 'n/a',reverse=True)
+        return move_na_to_end
 
     def __sort_tiebreak2(self,details):
         sort_by_name = sorted(details,key=lambda item:item.player_name)
         sort_by_difference = sorted(sort_by_name,key=lambda item:item.difference)
-        return sort_by_difference
+        move_na_to_end = sorted(sort_by_difference,key=lambda item:item.difference != 'n/a',reverse=True)
+        return move_na_to_end
 
     def __sort_tiebreak3(self,details):
         sort_by_name = sorted(details,key=lambda item:item.player_name)

--- a/pick10/tests/unit_test_database.py
+++ b/pick10/tests/unit_test_database.py
@@ -415,6 +415,30 @@ class UnitTestDatabase:
         kevin = self.setup_player(year,'Kevin')
         john = self.setup_player(year,'John')
 
+    def setup_week_no_picks(self,year=1975,week=2,game_state=FINAL):
+        week = self.setup_week(year,week_number=week)
+        games = [None]*10
+        games[0] = self.setup_game_with_winner(week,1,"Georgia Tech","Clemson",state=game_state,winner=TEAM1)
+        games[1] = self.setup_game_with_winner(week,2,"Duke","North Carolina",state=game_state,winner=TEAM2)
+        games[2] = self.setup_game_with_winner(week,3,"Virginia","Virginia Tech",state=game_state,winner=TEAM1)
+        games[3] = self.setup_game_with_winner(week,4,"Indiana","Maryland",state=game_state,winner=TEAM2)
+        games[4] = self.setup_game_with_winner(week,5,"South Carolina","Georgia",state=game_state,winner=TEAM1)
+        games[5] = self.setup_game_with_winner(week,6,"Tennessee","Vanderbilt",state=game_state,winner=TEAM2)
+        games[6] = self.setup_game_with_winner(week,7,"Auburn","Alabama",state=game_state,winner=TEAM1)
+        games[7] = self.setup_game_with_winner(week,8,"Southern California","UCLA",state=game_state,winner=TEAM2)
+        games[8] = self.setup_game_with_winner(week,9,"Army","Navy",state=game_state,winner=TEAM1)
+        games[9] = self.setup_game_with_winner(week,10,"Notre Dame","Florida State",state=game_state,winner=TEAM2)
+        brent = self.setup_player(year,'Brent')
+        byron = self.setup_player(year,'Byron')
+        alice = self.setup_player(year,'Alice')
+        joan = self.setup_player(year,'Joan')
+        bill = self.setup_player(year,'Bill')
+        david = self.setup_player(year,'David')
+        amy = self.setup_player(year,'Amy')
+        annie = self.setup_player(year,'Annie')
+        kevin = self.setup_player(year,'Kevin')
+        john = self.setup_player(year,'John')
+
     def setup_week(self,year,week_number):
         year_model = populate_year(year)
         week, created = Week.objects.get_or_create(year=year_model, weeknum=week_number)

--- a/pick10/tests/unit_test_database.py
+++ b/pick10/tests/unit_test_database.py
@@ -294,6 +294,40 @@ class UnitTestDatabase:
             self.setup_pick(kevin,game,winner=TEAM1)
             self.setup_pick(john,game,winner=TEAM1)
 
+    def setup_week_final_with_no_pick_defaulters(self,year=1978,week_number=11):
+        week = self.setup_week(year,week_number)
+        games = [None]*10
+        games[0] = self.setup_game_with_winner(week,1,"Georgia Tech","Clemson",state=FINAL,winner=TEAM1)
+        games[1] = self.setup_game_with_winner(week,2,"Duke","North Carolina",state=FINAL,winner=TEAM2)
+        games[2] = self.setup_game_with_winner(week,3,"Virginia","Virginia Tech",state=FINAL,winner=TEAM1)
+        games[3] = self.setup_game_with_winner(week,4,"Indiana","Maryland",state=FINAL,winner=TEAM2)
+        games[4] = self.setup_game_with_winner(week,5,"South Carolina","Georgia",state=FINAL,winner=TEAM1)
+        games[5] = self.setup_game_with_winner(week,6,"Tennessee","Vanderbilt",state=FINAL,winner=TEAM2)
+        games[6] = self.setup_game_with_winner(week,7,"Auburn","Alabama",state=FINAL,winner=TEAM1)
+        games[7] = self.setup_game_with_winner(week,8,"Southern California","UCLA",state=FINAL,winner=TEAM2)
+        games[8] = self.setup_game_with_winner(week,9,"Army","Navy",state=FINAL,winner=TEAM1)
+        games[9] = self.setup_game_with_winner(week,10,"Notre Dame","Florida State",state=FINAL,winner=TEAM2)
+        brent = self.setup_player(year,'Brent')
+        byron = self.setup_player(year,'Byron')
+        alice = self.setup_player(year,'Alice')
+        joan = self.setup_player(year,'Joan')
+        bill = self.setup_player(year,'Bill')
+        david = self.setup_player(year,'David')
+        amy = self.setup_player(year,'Amy')
+        annie = self.setup_player(year,'Annie')
+        kevin = self.setup_player(year,'Kevin')
+        john = self.setup_player(year,'John')
+        for game in games:
+            self.setup_pick(brent,game,winner=TEAM1)
+            self.setup_pick(byron,game,winner=TEAM1)
+            self.setup_pick(alice,game,winner=TEAM1)
+            self.setup_pick(joan,game,winner=TEAM1)
+            self.setup_pick(bill,game,winner=TEAM1)
+            self.setup_pick(david,game,winner=TEAM1)
+            self.setup_pick(amy,game,winner=TEAM1)
+            self.setup_pick(annie,game,winner=TEAM1)
+        # kevin, john have no picks
+
     def setup_week_not_started_no_picks(self,year=1978,week_number=11):
         week = self.setup_week(year,week_number)
         games = [None]*10

--- a/pick10/tests/unit_test_database.py
+++ b/pick10/tests/unit_test_database.py
@@ -226,6 +226,39 @@ class UnitTestDatabase:
         self.setup_player_picks_projected(kevin,games,wins=1,projected=2)
         self.setup_player_default(john,games)
 
+    def setup_week_in_progress_with_no_pick_defaulters(self,year=1978,week_number=8):
+        week = self.setup_week(year,week_number)
+        games = [None]*10
+        games[0] = self.setup_game_with_winner(week,1,"Georgia Tech","Clemson",state=FINAL,winner=TEAM1)
+        games[1] = self.setup_game_with_winner(week,2,"Duke","North Carolina",state=FINAL,winner=TEAM1)
+        games[2] = self.setup_game_with_winner(week,3,"Virginia","Virginia Tech",state=FINAL,winner=TEAM1)
+        games[3] = self.setup_game_with_winner(week,4,"Indiana","Maryland",state=FINAL,winner=TEAM2)
+        games[4] = self.setup_game_with_winner(week,5,"South Carolina","Georgia",state=FINAL,winner=TEAM2)
+        games[5] = self.setup_game_with_winner(week,6,"Tennessee","Vanderbilt",state=FINAL,winner=TEAM2)
+        games[6] = self.setup_game(week,7,"Auburn","Alabama",state=NOT_STARTED)
+        games[7] = self.setup_game(week,8,"Southern California","UCLA",state=NOT_STARTED)
+        games[8] = self.setup_game(week,9,"Army","Navy",state=NOT_STARTED)
+        games[9] = self.setup_game(week,10,"Notre Dame","Florida State",state=NOT_STARTED)
+        brent = self.setup_player(year,'Brent')
+        byron = self.setup_player(year,'Byron')
+        alice = self.setup_player(year,'Alice')
+        joan = self.setup_player(year,'Joan')
+        bill = self.setup_player(year,'Bill')
+        david = self.setup_player(year,'David')
+        amy = self.setup_player(year,'Amy')
+        annie = self.setup_player(year,'Annie')
+        kevin = self.setup_player(year,'Kevin')
+        john = self.setup_player(year,'John')
+        self.setup_player_picks(brent,games,number_of_wins=6)
+        self.setup_player_picks(byron,games,number_of_wins=6)
+        self.setup_player_picks(alice,games,number_of_wins=5)
+        self.setup_player_picks(joan,games,number_of_wins=5)
+        self.setup_player_picks(bill,games,number_of_wins=4)
+        self.setup_player_picks(david,games,number_of_wins=4)
+        self.setup_player_picks(amy,games,number_of_wins=3)
+        self.setup_player_picks(annie,games,number_of_wins=3)
+        # no picks for john, kevin
+
     def setup_week_final(self,year=1978,week_number=10):
         week = self.setup_week(year,week_number)
         games = [None]*10

--- a/pick10/tests/unit_test_database.py
+++ b/pick10/tests/unit_test_database.py
@@ -124,6 +124,40 @@ class UnitTestDatabase:
             self.setup_pick(kevin,game,winner=0)
             self.setup_pick(john,game,winner=0)
 
+    def setup_week_not_started_with_no_pick_defaulters(self,year=1978,week_number=13):
+        week = self.setup_week(year,week_number)
+        games = [None]*10
+        games[0] = self.setup_game(week,1,"Georgia Tech","Clemson",state=NOT_STARTED)
+        games[1] = self.setup_game(week,2,"Duke","North Carolina",state=NOT_STARTED)
+        games[2] = self.setup_game(week,3,"Virginia","Virginia Tech",state=NOT_STARTED)
+        games[3] = self.setup_game(week,4,"Indiana","Maryland",state=NOT_STARTED)
+        games[4] = self.setup_game(week,5,"South Carolina","Georgia",state=NOT_STARTED)
+        games[5] = self.setup_game(week,6,"Tennessee","Vanderbilt",state=NOT_STARTED)
+        games[6] = self.setup_game(week,7,"Auburn","Alabama",state=NOT_STARTED)
+        games[7] = self.setup_game(week,8,"Southern California","UCLA",state=NOT_STARTED)
+        games[8] = self.setup_game(week,9,"Army","Navy",state=NOT_STARTED)
+        games[9] = self.setup_game(week,10,"Notre Dame","Florida State",state=NOT_STARTED)
+        brent = self.setup_player(year,'Brent')
+        byron = self.setup_player(year,'Byron')
+        alice = self.setup_player(year,'Alice')
+        joan = self.setup_player(year,'Joan')
+        bill = self.setup_player(year,'Bill')
+        david = self.setup_player(year,'David')
+        amy = self.setup_player(year,'Amy')
+        annie = self.setup_player(year,'Annie')
+        kevin = self.setup_player(year,'Kevin')
+        john = self.setup_player(year,'John')
+        for game in games:
+            self.setup_pick(brent,game,winner=TEAM1)
+            self.setup_pick(byron,game,winner=TEAM1)
+            self.setup_pick(alice,game,winner=TEAM1)
+            self.setup_pick(joan,game,winner=TEAM1)
+            self.setup_pick(bill,game,winner=TEAM1)
+            self.setup_pick(david,game,winner=TEAM1)
+            self.setup_pick(amy,game,winner=TEAM1)
+            self.setup_pick(annie,game,winner=TEAM1)
+        # kevin, john don't have picks for the week
+
     def setup_week_in_progress(self,year=1978,week_number=8):
         week = self.setup_week(year,week_number)
         games = [None]*10

--- a/pick10/week_winner.py
+++ b/pick10/week_winner.py
@@ -262,9 +262,9 @@ class WeekWinner:
         for player_id in players:
             pick = self.__data.player_featured_game_picks[player_id]
 
-            # no score entered
-            if pick.team1_predicted_points == None or pick.team2_predicted_points == None:
+            if self.__pick_score_not_entered(pick):
                 self.players_lost_tiebreak1.append(player_id)
+                continue
 
             pick_spread = pick.team1_predicted_points - pick.team2_predicted_points
             pick_difference = abs(pick_spread-result_spread) 
@@ -427,7 +427,8 @@ class WeekWinner:
         return self.__data
 
     def __pick_score_not_entered(self,pick):
-        return pick.team1_predicted_points == None or pick.team2_predicted_points == None or\
+        return pick == None or\
+               pick.team1_predicted_points == None or pick.team2_predicted_points == None or\
                pick.team1_predicted_points < 0 or pick.team2_predicted_points < 0
 
     def __setup_data_to_use(self,year,week_number,week_data_supplied=None):

--- a/pick10/week_winner.py
+++ b/pick10/week_winner.py
@@ -222,7 +222,10 @@ class WeekWinner:
 
         for player_id in self.players_tied_for_first:
             player_pick = self.__data.player_featured_game_picks[player_id]
-            if player_pick.winner == featured_winner:
+
+            if player_pick == None:
+                self.players_lost_tiebreak0.append(player_id)
+            elif player_pick.winner == featured_winner:
                 self.players_won_tiebreak0.append(player_id)
             else: 
                 self.players_lost_tiebreak0.append(player_id)


### PR DESCRIPTION
I reviewed the code and made a few minor changes to support players with no Pick instances in a week.  A player that does not submit any picks for the week should be treated in the pool as a default for that week.

A few comments
```Python
# test pages are ok if some players have no picks
functional_test/test_no_picks.py

# fixed bug with player results page if player has no picks 
pick10/calculate_player_results.py  

# a few tweaks that likely won't matter
# a player with no picks shouldn't come into play when determining winner
pick10/calculate_tiebreak.py
pick10/week_winner.py

# create column for player without picks
pick10/excel_picks.py
```