### PR TITLE
set week winner to None if multiple winners in spreadsheet

### DIFF
--- a/excel_history/excel/pool_spreadsheet.py
+++ b/excel_history/excel/pool_spreadsheet.py
@@ -251,6 +251,28 @@ class PoolSpreadsheet:
 
         return None
 
+    def get_number_of_winners(self,week_number):
+        player_row = 1
+        first_player_column = 10
+        winner_row = 27
+        CELL_EMPTY = 0
+
+        sheet = self.__get_weekly_sheet(week_number)
+
+        num_winners = 0
+        for column in range(first_player_column,sheet.ncols):
+            winner = str(sheet.cell(winner_row,column).value) 
+            if sheet.cell_type(winner_row,column) == CELL_EMPTY or winner == "":
+                continue
+
+            if float(winner) == 1.0:
+                num_winners += 1
+
+        return num_winners
+
+    def has_multiple_winners(self,week_number):
+        return self.get_number_of_winners(week_number) > 1
+
     ##### Conference sheet
     def get_teams(self):
         if self.__teams != None:

--- a/stage_history.py
+++ b/stage_history.py
@@ -118,7 +118,7 @@ def populate_week(yearnum, weeknum, verbose=False):
     if created:
         poolspreadsheet = get_poolspreadsheet(yearnum)
         winner_ss_name = poolspreadsheet.get_week_winner(weeknum)
-        if winner_ss_name == None:
+        if winner_ss_name == None or poolspreadsheet.has_multiple_winners(weeknum):
             weekobj.winner = None
         else:
             populate_player_year(yearnum, winner_ss_name)


### PR DESCRIPTION
If the spreadsheet has more than 1 winner marked in a week, then this code sets the Week.winner field for that week to None.  Which means that pool will calculate the winner instead of using the Week.winner field.

This is what 2007 week 6 looks like with this change.

![screen shot 2015-09-08 at 4 16 56 pm](https://cloud.githubusercontent.com/assets/1541768/9746338/6bbf5d40-5645-11e5-85e6-8bf4eb514b16.png)

tiebreak page

![screen shot 2015-09-08 at 4 17 12 pm](https://cloud.githubusercontent.com/assets/1541768/9746340/701daeb4-5645-11e5-9e4d-7e9ba2aa563f.png)
